### PR TITLE
broken submodule reference to Python-API-Module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "epa/envirofacts/api"]
 	path = epa/envirofacts/api
-	url = git://github.com/codeforamerica/Python-API-Module.git
+	url = https://github.com/codeforamerica/Python-API-Module.git


### PR DESCRIPTION
Existing epa/envirofacts/api submodule reference doesn't exist (https://github.com/codeforamerica/Python-API-Module/tree/69e99a9fb03787551935d88afa8ae7a26255dc3d). I updated the submodule reference to current HEAD of the Python-API-Module (https://github.com/codeforamerica/Python-API-Module/commit/cf8722db15a98261167d7c34cf409466ef83b79d) to work with the Python EPA wrapper.
